### PR TITLE
Add config option to let Hyper window be visible on all workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ module.exports = {
 - Default: 0.4
 - The height of Hyper Overlay when it is showing.
 
+#### visibleOnAllWorkspaces
+- Value: true or false
+- Default: false
+- Let Hyper window be visible in all workspaces
+
 ### startAlone
 - Value: true or false
 - Default: false

--- a/overlay.js
+++ b/overlay.js
@@ -224,7 +224,9 @@ class Overlay {
     win.setResizable(this._config.resizable);
     win.setAlwaysOnTop(this._config.alwaysOnTop);
     if (this._config.visibleOnAllWorkspaces) {
-      win.setVisibleOnAllWorkspaces(true);
+      this._app.dock.hide();
+      win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true } );
+      win.setFullScreenable(false);
     }
   }
 

--- a/overlay.js
+++ b/overlay.js
@@ -170,6 +170,7 @@ class Overlay {
         width: 0.4,
         height: 0.4
       },
+      visibleOnAllWorkspaces: false,
       startAlone: false,
       startup: false,
       tray: true,
@@ -222,6 +223,9 @@ class Overlay {
     win.setHasShadow(this._config.hasShadow);
     win.setResizable(this._config.resizable);
     win.setAlwaysOnTop(this._config.alwaysOnTop);
+    if (this._config.visibleOnAllWorkspaces) {
+      win.setVisibleOnAllWorkspaces(true);
+    }
   }
 
   // get current display


### PR DESCRIPTION
On macOS, this lets Hyper be visible on all workspaces, when using the guake-style config, otherwise the window doesn't show ontop of full-screen apps.